### PR TITLE
Added new 'subzone' option to the 'Load' tab.

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -924,6 +924,15 @@ Private.load_prototype = {
 	  end
     },
     {
+      name = "subzone",
+      display = L["Subzone Name"],
+      type = "string",
+      init = "arg",
+      test = "WeakAuras.CheckString(%q, subzone)",
+      events = { "ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA", "VEHICLE_UPDATE" },
+      desc = L["Supports multiple entries, separated by commas"]
+    },
+    {
       name = "size",
       display = L["Instance Size Type"],
       type = "multiselect",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1231,7 +1231,7 @@ local function scanForLoadsImpl(toCheck, event, arg1, ...)
     return
   end
 
-  local player, realm, zone = UnitName("player"), GetRealmName(), GetRealZoneText();
+  local player, realm, zone, subzone = UnitName("player"), GetRealmName(), GetRealZoneText(), GetSubZoneText();
   local faction = UnitFactionGroup("player")
   local zoneId = GetCurrentMapAreaID()
 
@@ -1258,8 +1258,8 @@ local function scanForLoadsImpl(toCheck, event, arg1, ...)
     if (data and not data.controlledChildren) then
       local loadFunc = loadFuncs[id];
       local loadOpt = loadFuncsForOptions[id];
-      shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, size, difficulty);
-      couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, size, difficulty);
+      shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, subzone, size, difficulty);
+      couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, subzone, size, difficulty);
 
       if(shouldBeLoaded and not loaded[id]) then
         changed = changed + 1;


### PR DESCRIPTION
Subzone is the text on the minimap. It actually changes inside raids, and is a decent substitute for non-existent Encounter IDs in TBC. This feature will allow aura pack creators to load/unload auras dynamically in raids based on the current boss room (subzone) name.
I am actually using this feature for some time.